### PR TITLE
Support for `COMPOSER_BIN` environment variable

### DIFF
--- a/bin/local-php-security-checker-installer
+++ b/bin/local-php-security-checker-installer
@@ -10,15 +10,26 @@ if (!isset($versionOutput[0])) {
 
 $version = $versionOutput[0];
 
-$composerOutput = null;
-exec('composer --version >/dev/null 2>&1 && echo composer', $composerOutput);
+foreach (array(
+    'composer',
+    './composer',
+    'composer.phar',
+    './composer.phar',
+    'bin/composer',
+    'tools/composer',
+    'bin/composer.phar',
+    'tools/composer.phar',
+) as $popularComposerExecutableLocation) {
+    $composerOutput = null;
+    exec("{$popularComposerExecutableLocation} --version >/dev/null 2>&1 && echo ${popularComposerExecutableLocation}", $composerOutput);
+
+    if (isset($composerOutput[0])) {
+        break;
+    }
+}
 
 if (!isset($composerOutput[0])) {
-    exec('composer.phar --version >/dev/null 2>&1 && echo composer.phar', $composerOutput);
-
-    if (!isset($composerOutput[0])) {
-        exit(3);
-    }
+    exit(3);
 }
 
 $composer = $composerOutput[0];

--- a/bin/local-php-security-checker-installer
+++ b/bin/local-php-security-checker-installer
@@ -10,8 +10,21 @@ if (!isset($versionOutput[0])) {
 
 $version = $versionOutput[0];
 
+$composerOutput = null;
+exec('composer --version >/dev/null 2>&1 && echo composer', $composerOutput);
+
+if (!isset($composerOutput[0])) {
+    exec('composer.phar --version >/dev/null 2>&1 && echo composer.phar', $composerOutput);
+
+    if (!isset($composerOutput[0])) {
+        exit(3);
+    }
+}
+
+$composer = $composerOutput[0];
+
 $bindirOutput = null;
-exec('composer config bin-dir', $bindirOutput);
+exec("{$composer} config bin-dir", $bindirOutput);
 
 if (!isset($bindirOutput[0])) {
     exit(2);

--- a/bin/local-php-security-checker-installer
+++ b/bin/local-php-security-checker-installer
@@ -10,9 +10,8 @@ if (!isset($versionOutput[0])) {
 
 $version = $versionOutput[0];
 
-
 $bindirOutput = null;
-exec("composer config bin-dir", $bindirOutput);
+exec('composer config bin-dir', $bindirOutput);
 
 if (!isset($bindirOutput[0])) {
     exit(2);

--- a/bin/local-php-security-checker-installer
+++ b/bin/local-php-security-checker-installer
@@ -10,29 +10,7 @@ if (!isset($versionOutput[0])) {
 
 $version = $versionOutput[0];
 
-foreach (array(
-    'composer',
-    './composer',
-    'composer.phar',
-    './composer.phar',
-    'bin/composer',
-    'tools/composer',
-    'bin/composer.phar',
-    'tools/composer.phar',
-) as $popularComposerExecutableLocation) {
-    $composerOutput = null;
-    exec("{$popularComposerExecutableLocation} --version >/dev/null 2>&1 && echo ${popularComposerExecutableLocation}", $composerOutput);
-
-    if (isset($composerOutput[0])) {
-        break;
-    }
-}
-
-if (!isset($composerOutput[0])) {
-    exit(3);
-}
-
-$composer = $composerOutput[0];
+$composer = getenv('COMPOSER_BIN') ?: 'composer';
 
 $bindirOutput = null;
 exec("{$composer} config bin-dir", $bindirOutput);


### PR DESCRIPTION
Although `composer` is the most popular filename for PHP dependency manager, it's named `composer.phar` by default (i.e. when installed from the official [installer](https://getcomposer.org/installer) without any flags). This change introduces fallback to `composer.phar`, as well as multiple other executable locations, when `composer` isn't available.