### PR TITLE
Updated docs to show `$COMPOSER_BIN` usage and `bin-dir` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 # local-php-security-checker-installer
 Composer integration for local PHP security check using fabpot/local-php-security-checker
 
-Install:
+## Install:
 
 ```
 composer require thibautselingue/local-php-security-checker-installer
 ```
 
-Usage:
+Binary will be downloaded to your project's bin directory (`vendor/bin` by default, see [documentation](https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin-)).
+
+## Usage:
 
 ```
 vendor/bin/local-php-security-checker-installer && vendor/bin/local-php-security-checker
 ```
 
-Example in composer.json auto-scripts:
+Example passing path to Composer binary:
+```
+COMPOSER_BIN=./composer.phar vendor/bin/local-php-security-checker-installer && vendor/bin/local-php-security-checker
+```
+
+Example in `composer.json` auto-scripts:
 
 ```
 "scripts": {


### PR DESCRIPTION
In case lack of `bin-dir` or `$COMPOSER_BIN` description in `README.md` keeps you from tagging. Hope it helps. Feel free to reject if not needed. Cheers!