### PR TITLE
get platform and architecture to download correct binary

### DIFF
--- a/bin/local-php-security-checker-installer
+++ b/bin/local-php-security-checker-installer
@@ -25,7 +25,47 @@ if (!file_exists($bindir)) {
     mkdir($bindir, 0775, true);
 }
 
-exec("curl -LSs https://github.com/fabpot/local-php-security-checker/releases/download/v${version}/local-php-security-checker_${version}_linux_amd64 > ./{$bindir}/local-php-security-checker");
+$platform = null;
+exec("uname", $platform_output);
+
+switch($platform_output[0]){
+    case 'Darwin':
+        $platform = 'darwin';
+        break;
+    case 'Linux':
+        $platform = 'linux';
+        break;  
+    case 'WindowsNT':
+        $platform = 'windows';
+        break;
+    default:
+        $platform = 'linux';
+}
+
+$architecture_ouput = null;
+exec("uname -m", $architecture_ouput);
+
+switch($architecture_ouput[0]){
+    case 'arm':
+        $architecture = 'arm64';
+        break;
+    case 'aarch64':
+        $architecture = 'arm64';
+        break;
+    case 'i386':
+        $architecture = '386';
+        break;
+    case 'i686':
+        $architecture = '386';
+        break;
+    case 'x86_64':
+        $architecture = 'amd64';
+        break;
+    default:
+        $architecture = 'amd64';
+}
+
+exec("curl -LSs https://github.com/fabpot/local-php-security-checker/releases/download/v${version}/local-php-security-checker_${version}_${platform}_${architecture} > ./{$bindir}/local-php-security-checker");
 chmod("./{$bindir}/local-php-security-checker", 0755);
 
 ?>


### PR DESCRIPTION
Right now `local-php-security-checker` provides binaries for different platforms and architectures, see: https://github.com/fabpot/local-php-security-checker/releases/

Before this PR you did always download the `linux_amd64` version, which doesn't run on other platforms like macOS (see https://github.com/fabpot/local-php-security-checker/issues/5 or https://github.com/fabpot/local-php-security-checker/issues/11 as an example).

To download the specific binary needed this PR tries to get the needed info from `uname` & `uname -m` and download the specific binary.

This pr was tested on Linux x86_64 and macOS.